### PR TITLE
Specify multiple chain configs via CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore custom chain configs. Ex: `CHAIN_CONFIG=mycustom_chains.json make run`
+configs/*_chains.json

--- a/configs/logs.json
+++ b/configs/logs.json
@@ -2,15 +2,8 @@
   {
     "chain-id": "localjuno-1",
     "chain-name": "localjuno-1",
-    "rpc-address": "http://localhost:38455",
-    "grpc-address": "localhost:45823",
-    "ibc-path": "juno-ibc-1"
-  },
-  {
-    "chain-id": "localjuno-2",
-    "chain-name": "localjuno-2",
-    "rpc-address": "http://localhost:42319",
-    "grpc-address": "localhost:36343",
-    "ibc-path": "juno-ibc-1"
+    "rpc-address": "http://localhost:38829",
+    "grpc-address": "localhost:34917",
+    "ibc-path": ""
   }
 ]

--- a/src/config.go
+++ b/src/config.go
@@ -82,9 +82,18 @@ func loadConfig(config *MainConfig, filepath string) (*MainConfig, error) {
 	return config, nil
 }
 
-func LoadConfig() (*MainConfig, error) {
+func LoadConfig(chainCfgFile string) (*MainConfig, error) {
 	var config *MainConfig
-	config, _ = loadConfig(config, "../configs/chains.json")
+
+	filePath := "../configs/chains.json"
+	if chainCfgFile != "" {
+		filePath = "../configs/" + chainCfgFile
+	}
+
+	config, err := loadConfig(config, filePath)
+	if err != nil {
+		return nil, err
+	}
 	config, _ = loadConfig(config, "../configs/relayer.json")
 
 	chains := config.Chains

--- a/src/localjuno_test.go
+++ b/src/localjuno_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/strangelove-ventures/interchaintest/v7"
@@ -19,7 +20,8 @@ import (
 
 // TestLocalChains runs local IBC chain(s) easily.
 func TestLocalChains(t *testing.T) {
-	config, err := LoadConfig()
+	chainCfgFile := os.Getenv("CHAIN_CONFIG")
+	config, err := LoadConfig(chainCfgFile)
 	require.NoError(t, err)
 
 	WriteRunningChains([]byte("[]"))

--- a/src/main.go
+++ b/src/main.go
@@ -8,6 +8,6 @@ import (
 
 // go run main.go config.go
 func main() {
-	config, _ := LoadConfig()
+	config, _ := LoadConfig("chains.json")
 	fmt.Println(config)
 }


### PR DESCRIPTION
Closes #4 

`CHAIN_CONFIG=2_chains.json make run` will use the 2_chains.json config after it is created.
Useful if you have multiple networks you need to use without overriding the main one