### PR TITLE
ICTEST_HOME override, broad binary distribution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Follow [this guide](WINDOWS.md) to setup the Windows OS environment for installi
 - *(optional)* Edit `./configs/relayer.json`
 - Copy: `cp ./configs/chains.json ./configs/mytest1_ignored.json`
 - Run: `local-ic start mytest1_ignored.json`
-- Change directory `INSTALL_DIR=/root/example/local-interchain local-ic start myother_ignored.json`
+- Change directory `ICTEST_HOME=/root/example/local-interchain local-ic start myother_ignored.json`
+
+*(Default: `make install` links to the cloned directory. `go install .` will use your home directory /local-interchain)*
 
 *(Ending the config file with `_ignored.json` or `_ignore.json` will ignore it from git)*
 

--- a/cmd/local-ic/root.go
+++ b/cmd/local-ic/root.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"fmt"
+	"log"
 	"os"
+	"path"
 
 	"github.com/spf13/cobra"
 )
@@ -22,9 +25,20 @@ var rootCmd = &cobra.Command{
 }
 
 func GetDirectory() string {
-	installDir := os.Getenv("INSTALL_DIR")
-	if installDir != "" {
-		return installDir
+	// Config variable override for the ICTEST_HOME
+	if res := os.Getenv("ICTEST_HOME"); res != "" {
+		MakeFileInstallDirectory = res
+		return res
+	}
+
+	if MakeFileInstallDirectory == "" {
+		dirname, err := os.UserHomeDir()
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(dirname)
+
+		MakeFileInstallDirectory = path.Join(dirname, "local-interchain")
 	}
 
 	return MakeFileInstallDirectory


### PR DESCRIPTION
Closes #39 

Super useful so we can distribute pre-compile binaries and it link to the users correct install location

make install -> to the users git clone path
go install . -> users home directory (Windows, Mac, and Linux support)

env ICTEST_HOME overrides the above